### PR TITLE
#41 dialog 오픈 요청 들어오면 fastapi 422 응답하는 문제 개선

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,14 +2,14 @@ import asyncio
 import json
 import uuid
 from http import HTTPStatus
-from typing import Optional
+from typing import Optional, Annotated
 
-from fastapi import FastAPI, Response
+from fastapi import FastAPI, Response, Form
 from slack import WebClient
 
 from helper import post_book_to_notion
 from forms.book import SubmitRequest, UserProfileResponse, SlackResponse, SubmitRequestPayload
-from forms.dialog import DialogTrigger, Dialog, DialogElement
+from forms.dialog import Dialog, DialogElement
 from settings import settings
 
 app = FastAPI()
@@ -28,7 +28,7 @@ SUCCESS_MESSAGE: str = """
 
 
 @app.post("/open-form/")
-async def open_form(request: DialogTrigger) -> Response:
+async def open_form(trigger_id: Annotated[str, Form()]) -> Response:
     response = SlackResponse.parse_obj(
         await slack_client.dialog_open(  # type: ignore
             dialog=Dialog(
@@ -45,7 +45,7 @@ async def open_form(request: DialogTrigger) -> Response:
                     DialogElement(label="추천이유", name="recommend_reason", type="textarea"),
                 ],
             ).dict(),
-            trigger_id=request.trigger_id,
+            trigger_id=trigger_id,
         )
     )
 

--- a/forms/dialog.py
+++ b/forms/dialog.py
@@ -38,7 +38,3 @@ class Dialog(BaseModel):
     submit_label: str = "submit"
     callback_id: str
     notify_on_cancel: bool = True
-
-
-class DialogTrigger(BaseModel):
-    trigger_id: str

--- a/poetry.lock
+++ b/poetry.lock
@@ -1004,6 +1004,21 @@ files = [
 cli = ["click (>=5.0)"]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.6"
+description = "A streaming multipart parser for Python"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "python_multipart-0.0.6-py3-none-any.whl", hash = "sha256:ee698bab5ef148b0a760751c261902cd096e57e10558e11aca17646b74ee1c18"},
+    {file = "python_multipart-0.0.6.tar.gz", hash = "sha256:e9925a80bb668529f1b67c7fdb0a5dacdd7cbfc6fb0bff3ea443fe22bdd62132"},
+]
+
+[package.extras]
+dev = ["atomicwrites (==1.2.1)", "attrs (==19.2.0)", "coverage (==6.5.0)", "hatch", "invoke (==1.7.3)", "more-itertools (==4.3.0)", "pbr (==4.3.0)", "pluggy (==1.0.0)", "py (==1.11.0)", "pytest (==7.2.0)", "pytest-cov (==4.0.0)", "pytest-timeout (==2.1.0)", "pyyaml (==5.1)"]
+
+[[package]]
 name = "python-slugify"
 version = "8.0.1"
 description = "A Python slugify application that also handles Unicode"
@@ -1419,4 +1434,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "3.9.16"
-content-hash = "f977762ecaef0ac7e3348fd9e290265b47d43dfdc5c4b46d7517cc49dfd11865"
+content-hash = "447d4234238f22688c584433f61c8ba0019e640b3136ad850c19339599f1788b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ slackclient = "2.7.1"
 python-dotenv = "^1.0.0"
 gunicorn = "^20.1.0"
 httpx = "^0.23.3"
+python-multipart = "^0.0.6"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/test_open_form.py
+++ b/tests/test_open_form.py
@@ -162,7 +162,9 @@ def test_open_form_succeed(mocker, dialog_form_data, dialog_format, mock_uuid, m
     mocker.patch("app.slack_client.dialog_open", MagicMock(return_value=mock_dialog_open))
     mocker.patch("uuid.UUID", mock_uuid)
 
-    response = client.post("/open-form/", json=dialog_form_data)
+    response = client.post(
+        "/open-form/", data=dialog_form_data, headers={"Content-Type": "application/x-www-form-urlencoded"}
+    )
     assert response.status_code == HTTPStatus.OK
 
     slack_client.dialog_open.assert_called_once_with(trigger_id=dialog_form_data["trigger_id"], dialog=dialog_format)
@@ -173,8 +175,9 @@ def test_open_form_fail(mocker, dialog_form_data, dialog_format, mock_uuid, mock
     mocker.patch("app.slack_client.dialog_open", MagicMock(return_value=mock_dialog_open))
     mocker.patch("uuid.UUID", mock_uuid)
 
-    response = client.post("/open-form/", json=dialog_form_data)
-
+    response = client.post(
+        "/open-form/", data=dialog_form_data, headers={"Content-Type": "application/x-www-form-urlencoded"}
+    )
     assert response.status_code == HTTPStatus.OK
     assert response.content.decode() == "some-error"
 


### PR DESCRIPTION
[현상]
slack dialog form 오픈 시도하면 422 으로 응답

[원인]
* slack slash 커맨드는 content-type 을 `application/x-www-form-urlencoded` 으로 해서 요청 날림.
https://api.slack.com/interactivity/slash-commands#app_command_handling 
* fastapi 0.68 -> 0.95 버전 업 하고나서 디폴트로 `application/json` 으로 받음 -> json 형식으로 안들어와서 422 으로 응답. 

[해결]
https://fastapi.tiangolo.com/tutorial/request-forms/
form 형태로 받게 변경.

